### PR TITLE
Add missing tags to fix Sable weights

### DIFF
--- a/src/main/resources/data/c/tags/block/fences.json
+++ b/src/main/resources/data/c/tags/block/fences.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "alloyed:steel_mesh_fence"
+  ]
+}

--- a/src/main/resources/data/c/tags/block/ladders.json
+++ b/src/main/resources/data/c/tags/block/ladders.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "alloyed:steel_ladder"
+  ]
+}

--- a/src/main/resources/data/c/tags/block/storage_blocks.json
+++ b/src/main/resources/data/c/tags/block/storage_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#c:storage_blocks/bronze",
+    "#c:storage_blocks/steel"
+  ]
+}

--- a/src/main/resources/data/c/tags/item/fences.json
+++ b/src/main/resources/data/c/tags/item/fences.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "alloyed:steel_mesh_fence"
+  ]
+}

--- a/src/main/resources/data/c/tags/item/ingots.json
+++ b/src/main/resources/data/c/tags/item/ingots.json
@@ -1,7 +1,7 @@
 {
   "replace": false,
   "values": [
-    "alloyed:steel_ingot",
-    "alloyed:bronze_ingot"
+    "#c:ingots/steel",
+    "#c:ingots/bronze"
   ]
 }

--- a/src/main/resources/data/c/tags/item/nuggets.json
+++ b/src/main/resources/data/c/tags/item/nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#c:nuggets/bronze",
+    "#c:nuggets/steel"
+  ]
+}

--- a/src/main/resources/data/c/tags/item/plates.json
+++ b/src/main/resources/data/c/tags/item/plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#c:plates/bronze",
+    "#c:plates/steel"
+  ]
+}

--- a/src/main/resources/data/c/tags/item/storage_blocks.json
+++ b/src/main/resources/data/c/tags/item/storage_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#c:storage_blocks/bronze",
+    "#c:storage_blocks/steel"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/block/slabs.json
+++ b/src/main/resources/data/minecraft/tags/block/slabs.json
@@ -1,5 +1,17 @@
 {
   "values": [
-    "alloyed:steel_sheet_slab"
+    "alloyed:steel_sheet_slab",
+    "alloyed:cut_bronze_slab",
+    "alloyed:cut_exposed_bronze_slab",
+    "alloyed:cut_weathered_bronze_slab",
+    "alloyed:cut_oxidized_bronze_slab",
+    "alloyed:waxed_cut_bronze_slab",
+    "alloyed:waxed_cut_exposed_bronze_slab",
+    "alloyed:waxed_cut_weathered_bronze_slab",
+    "alloyed:waxed_cut_oxidized_bronze_slab",
+    {
+      "id": "alloyed:steel_sheet_vertical_slab",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/minecraft/tags/block/stairs.json
+++ b/src/main/resources/data/minecraft/tags/block/stairs.json
@@ -1,5 +1,17 @@
 {
   "values": [
-    "alloyed:steel_sheet_stairs"
+    "alloyed:steel_sheet_stairs",
+    "alloyed:cut_bronze_stairs",
+    "alloyed:cut_exposed_bronze_stairs",
+    "alloyed:cut_weathered_bronze_stairs",
+    "alloyed:cut_oxidized_bronze_stairs",
+    "alloyed:waxed_cut_bronze_stairs",
+    "alloyed:waxed_cut_exposed_bronze_stairs",
+    "alloyed:waxed_cut_weathered_bronze_stairs",
+    "alloyed:waxed_cut_oxidized_bronze_stairs",
+    {
+      "id": "alloyed:steel_catwalk_stairs",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/minecraft/tags/item/slabs.json
+++ b/src/main/resources/data/minecraft/tags/item/slabs.json
@@ -1,5 +1,17 @@
 {
   "values": [
-    "alloyed:steel_sheet_slab"
+    "alloyed:steel_sheet_slab",
+    "alloyed:cut_bronze_slab",
+    "alloyed:cut_exposed_bronze_slab",
+    "alloyed:cut_weathered_bronze_slab",
+    "alloyed:cut_oxidized_bronze_slab",
+    "alloyed:waxed_cut_bronze_slab",
+    "alloyed:waxed_cut_exposed_bronze_slab",
+    "alloyed:waxed_cut_weathered_bronze_slab",
+    "alloyed:waxed_cut_oxidized_bronze_slab",
+    {
+      "id": "alloyed:steel_sheet_vertical_slab",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/minecraft/tags/item/stairs.json
+++ b/src/main/resources/data/minecraft/tags/item/stairs.json
@@ -1,5 +1,17 @@
 {
   "values": [
-    "alloyed:steel_sheet_stairs"
+    "alloyed:steel_sheet_stairs",
+    "alloyed:cut_bronze_stairs",
+    "alloyed:cut_exposed_bronze_stairs",
+    "alloyed:cut_weathered_bronze_stairs",
+    "alloyed:cut_oxidized_bronze_stairs",
+    "alloyed:waxed_cut_bronze_stairs",
+    "alloyed:waxed_cut_exposed_bronze_stairs",
+    "alloyed:waxed_cut_weathered_bronze_stairs",
+    "alloyed:waxed_cut_oxidized_bronze_stairs",
+    {
+      "id": "alloyed:steel_catwalk_stairs",
+      "required": false
+    }
   ]
 }


### PR DESCRIPTION
Adds missing tags such as `#minecraft:stairs`/`slabs`, and `#c:fences`/`ladders`. This makes Sable properly recognize the weight of many blocks.

This PR as a datapack: [alloyed_tag_fix.zip](https://github.com/user-attachments/files/29263709/alloyed_tag_fix.zip)
